### PR TITLE
Use info level for http requests instead of debug to reduce clutter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
+                format!("{}=info,tower_http=info", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())


### PR DESCRIPTION
Makes the log only 1 line instead of like 7 for each frame that gets sent
